### PR TITLE
Updated plugin IDs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Fetch all tags
       run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Run build
-      run: .\gradlew.bat build -i --scan --continue
+      run: .\gradlew.bat build --scan --continue
 
   build:
 
@@ -28,7 +28,7 @@ jobs:
     - name: Fetch all tags
       run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Run build
-      run: ./gradlew build -i --scan --continue
+      run: ./gradlew build --scan --continue
 #    - name: Deploy to plugins.gradle.org
 #      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
 #      run: ./gradlew createTag pushTag publishPlugins -i --scan

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,21 @@
-plugins {
-    id 'org.shipkit.shipkit-auto-version' version "0.0.32"
-    id 'java-gradle-plugin'
-    id "com.gradle.plugin-publish" version "0.12.0"
-    id 'groovy'
-    id 'idea'
-    id 'maven-publish'
+buildscript {
+    repositories {
+        mavenLocal()        // for local testing
+        maven { url "https://plugins.gradle.org/m2/" }
+    }
+    dependencies {
+        classpath 'org.shipkit:shipkit-auto-version:0.0.32'
+        classpath "com.gradle.publish:plugin-publish-plugin:0.12.0"
+    }
 }
+
+apply plugin: 'groovy'
+apply plugin: 'idea'
+apply plugin: 'maven-publish'
+apply plugin: 'java-gradle-plugin'
+
+apply plugin: 'org.shipkit.shipkit-auto-version'
+apply plugin: 'com.gradle.plugin-publish'
 
 group = "org.shipkit"
 

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -2,11 +2,11 @@
 gradlePlugin {
     plugins {
         changelog {
-            id = 'org.shipkit.changelog'
+            id = 'org.shipkit.shipkit-changelog'
             implementationClass = 'org.shipkit.changelog.ChangelogPlugin'
         }
         gitHubRelease {
-            id = 'org.shipkit.gh.release'
+            id = 'org.shipkit.shipkit-gh-release'
             implementationClass = 'org.shipkit.gh.release.GitHubReleasePlugin'
         }
     }

--- a/src/integTest/groovy/org/shipkit/gh/release/GitHubReleasePluginIntegTest.groovy
+++ b/src/integTest/groovy/org/shipkit/gh/release/GitHubReleasePluginIntegTest.groovy
@@ -15,7 +15,7 @@ class GitHubReleasePluginIntegTest extends Specification {
     def setup() {
         file("settings.gradle")
         file("build.gradle") << """
-            plugins {  id('org.shipkit.gh.release') }
+            plugins {  id('org.shipkit.shipkit-gh-release') }
         """
     }
 


### PR DESCRIPTION
Updated plugin IDs. This way, they are consistent with other 'org.shipkit' plugins

Also converted the plugin style. The "old" style of applying plugins enables us to test locally built versions easily