### PR TITLE
Added click to CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![CI](https://github.com/shipkit/shipkit-changelog/workflows/CI/badge.svg)
+[![CI](https://github.com/shipkit/shipkit-changelog/workflows/CI/badge.svg)](https://github.com/shipkit/shipkit-changelog/actions)
 
 # Shipkit Changelog Gradle plugin
 


### PR DESCRIPTION
CI badge redirects now to shipkit-changelog's actions history.