### PR TITLE
Applied full history fetching.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2   # docs: https://github.com/actions/checkout
-    - name: Fetch all tags
-      run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      with:
+        fetch-depth: '0'
     - name: Run build
       run: .\gradlew.bat build --scan --continue
 


### PR DESCRIPTION
According to issue #26 same fix as https://github.com/shipkit/shipkit-auto-version/pull/32 is applied in order to generate release notes reliably.