### PR TITLE
Add support for CI and release skipping

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,9 @@
+#
+# CI build that also make relases from the main dev branch.
+#
+# - skipping CI: add [skip ci] to the commit message
+# - skipping release: add [skip release] to the commit message
+#
 name: CI
 
 on:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   windows_build:
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2   # docs: https://github.com/actions/checkout
@@ -30,7 +31,10 @@ jobs:
     - name: Run build
       run: ./gradlew build --scan --continue
     - name: Perform release (tagging, changelog, deployment to plugins.gradle.org)
-      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
+      if: success()
+          && github.event_name == 'push'
+          && github.ref == 'refs/heads/master'
+          && !contains(toJSON(github.event.commits.*.message), '[skip release]')
       run: ./gradlew publishPlugins githubRelease --scan
       env:
           # Gradle env variables docs: https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_environment_variables


### PR DESCRIPTION
In some cases we don't want to trigger build or deployment with commit pushing. In order to achieve this, test that checks if commit message contains "[skip ci]" or "[skip release]" can be added to CI workflow.