### PR TITLE
Removed redundant check from GH workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,7 @@ jobs:
     - name: Run build
       run: ./gradlew build --scan --continue
     - name: Perform release (tagging, changelog, deployment to plugins.gradle.org)
-      if: success()
-          && github.event_name == 'push'
+      if: github.event_name == 'push'
           && github.ref == 'refs/heads/master'
           && !contains(toJSON(github.event.commits.*.message), '[skip release]')
       run: ./gradlew publishPlugins githubRelease --scan


### PR DESCRIPTION
There is no need to test _success()_ in CI workflow - if previous step does not pass, next is not executed by deafult.