### PR TITLE
Bump Gradle Enterprise version

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.gradle.enterprise" version "3.3.4"
+    id "com.gradle.enterprise" version "3.5"
 }
 
 rootProject.name = "shipkit-changelog"


### PR DESCRIPTION
Updated settings.gradle by bumping Gradle Enterprise version (to 3.5).
Tested by running the build.