### PR TITLE
Updated settings.gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -8,5 +8,6 @@ gradleEnterprise {
     buildScan {
         termsOfServiceUrl = "https://gradle.com/terms-of-service"
         termsOfServiceAgree = "yes"
+        uploadInBackground = System.getenv("CI") == null
     }
 }


### PR DESCRIPTION
Ensured Gradle build scans are published from CI builds, as recommended by Gradle Enterprise: https://docs.gradle.com/enterprise/gradle-plugin/#disabling_programmatically