### PR TITLE
Updated CI workflow to avoid failures in forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
     - name: Perform release (tagging, changelog, deployment to plugins.gradle.org)
       if: github.event_name == 'push'
           && github.ref == 'refs/heads/master'
+          && github.repository == 'shipkit/shipkit-changelog'
           && !contains(toJSON(github.event.commits.*.message), '[skip release]')
       run: ./gradlew publishPlugins githubRelease --scan
       env:


### PR DESCRIPTION
Repository path test in CI workflow will prevent getting "release" job failures, which are being get in contributors' GH Actions, when they push commits to their forks.
Same change was earlier done by @mockitoguy here: mockito/mockito@f5419b0; also submitted by me to Shipkit Auto Version: https://github.com/shipkit/shipkit-auto-version/pull/44