### PR TITLE
Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Depandabot can be added to keep dependencies up to date. Dependabot checks if any of dependencies are out-of-date, and if such dependency is found the pull request is opened to bump its version. It is enabled and configured in _dependabot.yml_ file. Dependabot was also added  by @sullis to Shipkit Auto Version: https://github.com/shipkit/shipkit-auto-version/pull/45