### PR TITLE
Remove unused Logger instantiation

### DIFF
--- a/src/main/java/org/shipkit/changelog/ChangelogPlugin.java
+++ b/src/main/java/org/shipkit/changelog/ChangelogPlugin.java
@@ -2,8 +2,6 @@ package org.shipkit.changelog;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.api.specs.Specs;
 
 import java.io.File;
@@ -13,8 +11,6 @@ import java.util.Date;
  * The plugin, ideally with zero business logic, but only the Gradle integration code
  */
 public class ChangelogPlugin implements Plugin<Project> {
-
-    private static final Logger LOG = Logging.getLogger(ChangelogPlugin.class);
 
     public void apply(Project project) {
         project.getTasks().register("generateChangelog", GenerateChangelogTask.class, t -> {


### PR DESCRIPTION
Removing unused variables helps to keep code clean and clear. 
As final variable LOG in ChangelogPlugin class is not used, it can be safely removed.