### PR TITLE
Update customers and sample projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ has negligible performance implication (adds ~2 secs to the checkout).
 - https://github.com/shipkit/shipkit-demo (great example/reference project)
 - https://github.com/shipkit/shipkit-changelog (this project)
 - https://github.com/shipkit/shipkit-auto-version
+- https://github.com/mockito/mockito
 - https://github.com/mockito/mockito-scala
+- https://github.com/mockito/mockito-testng
 
 ## Other plugins/tools
 


### PR DESCRIPTION
Information about projects that use Shipkit Changelog plugin is contained in README.md documentation. The plugin is used by Mockito and Mockito for TestNG, so the documentation can be updated with this info.