### PR TITLE
Simplified plugin configuration by making readOnlyToken optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /build/
 
 # Idea files / dirs
+.idea
 .shelf
 out
 *.iml

--- a/README.md
+++ b/README.md
@@ -63,8 +63,14 @@ Realistic example, also uses a sibling plugin [shipkit-auto-version](https://git
 The standard way to enable automated tasks read/write to GitHub are [personal access tokens](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token#creating-a-token).
 When creating the tokens, please select the following token **scopes** ([more info on scopes](https://docs.github.com/en/free-pro-team@latest/developers/apps/scopes-for-oauth-apps)):
 
+When using GH actions you can use [GITHUB_TOKEN](https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow) 
+for `readOnlyToken` and `writeToken`
+
 - readOnlyToken - should have **no scope**, this way it only provides read-only access to **public** repositories
 (it **does not** provide read-only access to private repositories).
+  
+  You can leave this field empty for local development, in this case you are limited to 60  requests per hour.  
+
 - writeToken - needs 'repo/public_repo' scope to post releases via GH REST API.
 
 ### Fetch depth on CI
@@ -181,7 +187,7 @@ Complete task configuration
         //The release version, default as below
         version = project.version       
         
-        //Token that enables querying GitHub, safe to check-in because it is read-only, *no default*              
+        //Token that enables querying GitHub, safe to check-in because it is read-only, default empty              
         readOnlyToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
         
         //Repository to look for tickets, *no default*

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ plugins {
 
 tasks.named("generateChangelog") {
     previousRevision = "v0.0.1"
-    readOnlyToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
+    readOnlyToken = "1234c0f41c200f7c653323014d6a72a127764e17"
     repository = "shipkit/shipkit-changelog"
 }
 
@@ -44,7 +44,7 @@ Realistic example, also uses a sibling plugin [shipkit-auto-version](https://git
 
     tasks.named("generateChangelog") {
         previousRevision = "v" + project.ext.'shipkit-auto-version.previous-version'
-        readOnlyToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
+        readOnlyToken = "1234c0f41c200f7c653323014d6a72a127764e17"
         repository = "shipkit/shipkit-changelog"
     }
     
@@ -69,7 +69,7 @@ for `readOnlyToken` and `writeToken`
 - readOnlyToken - should have **no scope**, this way it only provides read-only access to **public** repositories
 (it **does not** provide read-only access to private repositories).
   
-  You can leave this field empty for local development, in this case you are limited to 60  requests per hour.  
+  You can leave this field empty for local development, in this case you are limited to 60 requests per hour.  
 
 - writeToken - needs 'repo/public_repo' scope to post releases via GH REST API.
 
@@ -149,7 +149,7 @@ Basic task configuration
     
     tasks.named("generateChangelog") {
         previousRevision = "v3.3.10"
-        readOnlyToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
+        readOnlyToken = "1234c0f41c200f7c653323014d6a72a127764e17"
         repository = "mockito/mockito"
     }
 ```
@@ -187,8 +187,8 @@ Complete task configuration
         //The release version, default as below
         version = project.version       
         
-        //Token that enables querying GitHub, safe to check-in because it is read-only, default empty              
-        readOnlyToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
+        //Optional token (null by default) that enables querying GitHub with higher rate limit, safe to check-in because it is read-only
+        readOnlyToken = "1234c0f41c200f7c653323014d6a72a127764e17"
         
         //Repository to look for tickets, *no default*
         repository = "mockito/mockito"

--- a/src/main/java/org/shipkit/changelog/GenerateChangelogTask.java
+++ b/src/main/java/org/shipkit/changelog/GenerateChangelogTask.java
@@ -5,6 +5,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
@@ -117,6 +118,7 @@ public class GenerateChangelogTask extends DefaultTask {
      * Read-only GitHub token used to pull GitHub issues
      */
     @Input
+    @Optional
     public String getReadOnlyToken() {
         return readOnlyToken;
     }

--- a/src/main/java/org/shipkit/changelog/GitHubApi.java
+++ b/src/main/java/org/shipkit/changelog/GitHubApi.java
@@ -42,7 +42,9 @@ public class GitHubApi {
         c.setRequestMethod(method);
         c.setDoOutput(true);
         c.setRequestProperty("Content-Type", "application/json");
-        c.setRequestProperty("Authorization", "token " + authToken);
+        if (authToken != null) {
+            c.setRequestProperty("Authorization", "token " + authToken);
+        }
 
         if (body.isPresent()) {
             try (OutputStream os = c.getOutputStream()) {
@@ -79,7 +81,7 @@ public class GitHubApi {
             return IOUtil.readFully(conn.getInputStream());
         } else {
             String errorMessage =
-                String.format("%s %s failed, response code = %s, response body:\n%s",
+                String.format("%s %s failed, response code = %s, response body:%n%s",
                     method, conn.getURL(), conn.getResponseCode(), IOUtil.readFully(conn.getErrorStream()));
             throw new IOException(errorMessage);
         }

--- a/src/test/groovy/org/shipkit/changelog/GitHubTicketFetcherIntegTest.groovy
+++ b/src/test/groovy/org/shipkit/changelog/GitHubTicketFetcherIntegTest.groovy
@@ -17,4 +17,16 @@ class GitHubTicketFetcherIntegTest extends Specification {
 {id=1927, title='Fix import order', url='https://github.com/mockito/mockito/pull/1927'}
 {id=1922, title='[build] add ben-manes dependency upgrade finder', url='https://github.com/mockito/mockito/pull/1922'}"""
     }
+
+    def "fetches from GitHub without token"() {
+        def fetcher = new GitHubTicketFetcher("https://api.github.com", "mockito/mockito", null)
+
+        when:
+        //TODO: we need to query a repo that is dedicated for this test and validate that pagination works
+        def tickets = fetcher.fetchTickets(["1927"])
+
+        then:
+        tickets.join("\n") == """{id=1927, title='Fix import order', url='https://github.com/mockito/mockito/pull/1927'}"""
+    }
+
 }


### PR DESCRIPTION
Fixes #47

No it is optional to explicitly specify the ```readOnlyToken```.