### PR TITLE
Fixed releases inconsistency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "org.shipkit:shipkit-auto-version:0.0.+"
-        classpath "org.shipkit:shipkit-changelog:0.0.+"
+        classpath "org.shipkit:shipkit-auto-version:+"
+        classpath "org.shipkit:shipkit-changelog:+"
         classpath "com.gradle.publish:plugin-publish-plugin:0.12.0"
     }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=0.0.*
+version=0.1.*


### PR DESCRIPTION
Previously we accidentally published 0.0.45 version to Gradle plugin while the highest tag we have is 0.0.30

Addresses a portion of #51