### PR TITLE
Fixed the release build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "org.shipkit:shipkit-auto-version:+"
+        classpath "org.shipkit:shipkit-auto-version:0.+"
         classpath "org.shipkit:shipkit-changelog:+"
         classpath "com.gradle.publish:plugin-publish-plugin:0.12.0"
     }


### PR DESCRIPTION
We cannot depend on 1.* version of auto-version-plugin due to this problem: https://github.com/shipkit/shipkit-changelog/issues/51