### PR TITLE
Made release failures easier to recover

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           && github.ref == 'refs/heads/master'
           && github.repository == 'shipkit/shipkit-changelog'
           && !contains(toJSON(github.event.commits.*.message), '[skip release]')
-      run: ./gradlew publishPlugins githubRelease --scan
+      run: ./gradlew githubRelease publishPlugins --scan
       env:
           # Gradle env variables docs: https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_environment_variables
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}


### PR DESCRIPTION
Currently, it is difficult to recover from failures when the release step fails. For example, we have accidentally published 1.0.0 version some time ago (more info: https://github.com/shipkit/shipkit-changelog/issues/51). Now it is not possible to delete this version.

This change reorders the release steps: *first* we tag and release on GitHub (easy to revert), *then* we publish to Gradle plugins portal (harder to revert). 

This change prevents problems like https://github.com/shipkit/shipkit-changelog/issues/51 and makes them easier to recover from.