### PR TITLE
Add 'newTagRevision' property to fix tagging problem

### DIFF
--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -47,5 +47,6 @@ tasks.named("githubRelease") {
     dependsOn tasks.named("generateChangelog")
     repository = "shipkit/shipkit-changelog"
     changelog = tasks.named("generateChangelog").get().outputFile
+    newTagRevision = System.getenv("GITHUB_SHA")
     writeToken = System.getenv("GITHUB_TOKEN")
 }

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -47,6 +47,7 @@ tasks.named("githubRelease") {
     dependsOn tasks.named("generateChangelog")
     repository = "shipkit/shipkit-changelog"
     changelog = tasks.named("generateChangelog").get().outputFile
-    newTagRevision = System.getenv("GITHUB_SHA")
+//    After publishing new version of the plugin remove comment on 'newTagRevision' below:
+//    newTagRevision = System.getenv("GITHUB_SHA")
     writeToken = System.getenv("GITHUB_TOKEN")
 }

--- a/src/integTest/groovy/org/shipkit/gh/release/GitHubReleasePluginIntegTest.groovy
+++ b/src/integTest/groovy/org/shipkit/gh/release/GitHubReleasePluginIntegTest.groovy
@@ -72,6 +72,7 @@ class GitHubReleasePluginIntegTest extends BaseSpecification {
             tasks.named("githubRelease") {
                 repository = "shipkit/shipkit-changelog"
                 changelog = file("changelog.md")
+                newTagRevision = "ff2fb22b3bb2fb08164c126c0e2055d57dee441b"
                 writeToken = "secret"
             }
         """

--- a/src/main/java/org/shipkit/gh/release/GitHubReleaseTask.java
+++ b/src/main/java/org/shipkit/gh/release/GitHubReleaseTask.java
@@ -81,11 +81,19 @@ public class GitHubReleaseTask extends DefaultTask {
         this.writeToken = writeToken;
     }
 
+    /**
+     * See {@link #setNewTagRevision(String)}
+     */
     @Input
     public String getNewTagRevision() {
         return newTagRevision;
     }
 
+    /**
+     * Property required to specify revision for the new tag.
+     * The property's value is passed to GitHub API's
+     * 'target_commitish' parameter in {@link #postRelease()} method.
+     */
     public void setNewTagRevision(String newTagRevision) {
         this.newTagRevision = newTagRevision;
     }

--- a/src/main/java/org/shipkit/gh/release/GitHubReleaseTask.java
+++ b/src/main/java/org/shipkit/gh/release/GitHubReleaseTask.java
@@ -25,6 +25,7 @@ public class GitHubReleaseTask extends DefaultTask {
     private String releaseTag = null;
     private File changelog = null;
     private String writeToken = null;
+    private String newTagRevision = null;
 
     @Input
     public String getGhApiUrl() {
@@ -80,12 +81,22 @@ public class GitHubReleaseTask extends DefaultTask {
         this.writeToken = writeToken;
     }
 
+    @Input
+    public String getNewTagRevision() {
+        return newTagRevision;
+    }
+
+    public void setNewTagRevision(String newTagRevision) {
+        this.newTagRevision = newTagRevision;
+    }
+
     @TaskAction public void postRelease() {
         String url = ghApiUrl + "/repos/" + repository + "/releases";
 
         JsonObject body = new JsonObject();
         body.add("tag_name", releaseTag);
         body.add("name", releaseName);
+        body.add("target_commitish", newTagRevision);
         String releaseNotesTxt = IOUtil.readFully(changelog);
         body.add("body", releaseNotesTxt);
 


### PR DESCRIPTION
Fixes #46
Using _'newTagRevision'_ property eliminates problem with wrong tagging, when release is tagged with revision reference that the release doesn't come from, but is the latest one on master branch.
To solve the problem revision from which release is created has to be specified with GH API _'target_commitish'_ parameter. To get the revision default GitHub Actions environmental variable _'GITHUB_SHA'_ is used.
The solution was tested with the Shipkit Changelog plugin published to local Maven repository.