### PR TITLE
Configure Shipkit Changelog for using new property

### DIFF
--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -47,7 +47,6 @@ tasks.named("githubRelease") {
     dependsOn tasks.named("generateChangelog")
     repository = "shipkit/shipkit-changelog"
     changelog = tasks.named("generateChangelog").get().outputFile
-//    After publishing new version of the plugin remove comment on 'newTagRevision' below:
-//    newTagRevision = System.getenv("GITHUB_SHA")
+    newTagRevision = System.getenv("GITHUB_SHA")
     writeToken = System.getenv("GITHUB_TOKEN")
 }


### PR DESCRIPTION
After the release of the plugin version with 'newTagRevision', the property is ready to use.