### PR TITLE
Simplify token configuration

### DIFF
--- a/src/main/java/org/shipkit/changelog/GenerateChangelogTask.java
+++ b/src/main/java/org/shipkit/changelog/GenerateChangelogTask.java
@@ -22,7 +22,7 @@ public class GenerateChangelogTask extends DefaultTask {
     private String ghUrl;
     private File outputFile;
     private File workingDir;
-    private String readOnlyToken;
+    private String githubToken;
     private String ghApiUrl;
     private String repository;
     private String previousRevision;
@@ -115,16 +115,38 @@ public class GenerateChangelogTask extends DefaultTask {
     }
 
     /**
-     * Read-only GitHub token used to pull GitHub issues
+     * Deprecated, please use {@link #getGithubToken()}
      */
     @Input
     @Optional
+    @Deprecated
     public String getReadOnlyToken() {
-        return readOnlyToken;
+        return getGithubToken();
     }
 
+    /**
+     * Deprecated, please use {@link #setGithubToken(String)}
+     */
+    @Deprecated
     public void setReadOnlyToken(String readOnlyToken) {
-        this.readOnlyToken = readOnlyToken;
+        this.setGithubToken(readOnlyToken);
+    }
+
+    /**
+     * See {@link #setGithubToken(String)}
+     */
+    @Input
+    public String getGithubToken() {
+        return githubToken;
+    }
+
+    /**
+     * GitHub token used to pull GitHub issues.
+     * The same token is used to post a new release:
+     * {@link org.shipkit.gh.release.GitHubReleaseTask#setGithubToken(String)}
+     */
+    public void setGithubToken(String githubToken) {
+        this.githubToken = githubToken;
     }
 
     @TaskAction public void generateChangelog() {
@@ -144,7 +166,7 @@ public class GenerateChangelogTask extends DefaultTask {
 
         LOG.lifecycle("Fetching ticket info from {}/{} based on {} ids {}", ghApiUrl, repository, ticketIds.size(), ticketIds);
 
-        GitHubTicketFetcher fetcher = new GitHubTicketFetcher(ghApiUrl, repository, readOnlyToken);
+        GitHubTicketFetcher fetcher = new GitHubTicketFetcher(ghApiUrl, repository, githubToken);
         Collection<Ticket> improvements = fetcher.fetchTickets(ticketIds);
 
         LOG.lifecycle("Generating changelog based on {} tickets from GitHub", improvements.size());

--- a/src/main/java/org/shipkit/changelog/GitHubListFetcher.java
+++ b/src/main/java/org/shipkit/changelog/GitHubListFetcher.java
@@ -12,11 +12,11 @@ import java.io.IOException;
 class GitHubListFetcher {
 
     private static final String NO_MORE_PAGES = "none";
-    private final String readOnlyAuthToken;
+    private final String githubToken;
     private String nextPageUrl;
 
-    GitHubListFetcher(String apiUrl, String repository, String readOnlyAuthToken) {
-        this.readOnlyAuthToken = readOnlyAuthToken;
+    GitHubListFetcher(String apiUrl, String repository, String githubToken) {
+        this.githubToken = githubToken;
 
         // see API doc: https://developer.github.com/v3/issues/
         nextPageUrl = apiUrl + "/repos/" + repository + "/issues?page=1"
@@ -42,7 +42,7 @@ class GitHubListFetcher {
             throw new IllegalStateException("GitHub API has no more issues to fetch. Did you run 'hasNextPage()' method?");
         }
 
-        GitHubApi api = new GitHubApi(readOnlyAuthToken);
+        GitHubApi api = new GitHubApi(githubToken);
         GitHubApi.Response response = api.get(nextPageUrl);
 
         nextPageUrl = getNextPageUrl(response.getLinkHeader());

--- a/src/main/java/org/shipkit/changelog/GitHubTicketFetcher.java
+++ b/src/main/java/org/shipkit/changelog/GitHubTicketFetcher.java
@@ -11,8 +11,8 @@ class GitHubTicketFetcher {
     private static final Logger LOG = Logger.getLogger(GitHubTicketFetcher.class.getName());
     private final GitHubListFetcher fetcher;
 
-    GitHubTicketFetcher(String apiUrl, String repository, String readOnlyToken) {
-        this(new GitHubListFetcher(apiUrl, repository, readOnlyToken));
+    GitHubTicketFetcher(String apiUrl, String repository, String githubToken) {
+        this(new GitHubListFetcher(apiUrl, repository, githubToken));
     }
 
     GitHubTicketFetcher(GitHubListFetcher fetcher) {

--- a/src/main/java/org/shipkit/gh/release/GitHubReleaseTask.java
+++ b/src/main/java/org/shipkit/gh/release/GitHubReleaseTask.java
@@ -24,7 +24,7 @@ public class GitHubReleaseTask extends DefaultTask {
     private String releaseName = null;
     private String releaseTag = null;
     private File changelog = null;
-    private String writeToken = null;
+    private String githubToken = null;
     private String newTagRevision = null;
 
     @Input
@@ -72,13 +72,39 @@ public class GitHubReleaseTask extends DefaultTask {
         this.changelog = changelog;
     }
 
+    /**
+     * Deprecated, please use {@link #getGithubToken()}
+     */
     @Input
+    @Deprecated
     public String getWriteToken() {
-        return writeToken;
+        return getGithubToken();
     }
 
+    /**
+     * Deprecated, please use {@link #setGithubToken(String)}
+     */
+    @Deprecated
     public void setWriteToken(String writeToken) {
-        this.writeToken = writeToken;
+        this.setGithubToken(writeToken);
+    }
+
+    /**
+     * See {@link #setGithubToken(String)}
+     */
+    @Input
+    public String getGithubToken() {
+        return githubToken;
+    }
+
+    /**
+     * Token required by GH API to post a new release.
+     * This token should have *write* permission to the repo.
+     *
+     * @param githubToken token with write permissions
+     */
+    public void setGithubToken(String githubToken) {
+        this.githubToken = githubToken;
     }
 
     /**
@@ -108,7 +134,7 @@ public class GitHubReleaseTask extends DefaultTask {
         String releaseNotesTxt = IOUtil.readFully(changelog);
         body.add("body", releaseNotesTxt);
 
-        GitHubApi gitHubApi = new GitHubApi(writeToken);
+        GitHubApi gitHubApi = new GitHubApi(githubToken);
         try {
             String response = gitHubApi.post(url, body.toString());
             String htmlUrl = Json.parse(response).asObject().getString("html_url", "");
@@ -118,7 +144,7 @@ public class GitHubReleaseTask extends DefaultTask {
                     "  - url: " + url + "\n" +
                     "  - release tag: " + releaseTag + "\n" +
                     "  - release name: " + releaseName + "\n" +
-                    "  - token: " + writeToken.substring(0, 3) + "...\n" +
+                    "  - token: " + githubToken.substring(0, 3) + "...\n" +
                     "  - content:\n" + releaseNotesTxt + "\n"
                     , e);
         }


### PR DESCRIPTION
Resolves #50
Currently 2 different tokens are used to authenticate in GitHub API: _'readOnlyToken'_ that is used for fetching tickets and _'writeToken'_ to post releases.
Read token can be checked-in into the *.gradle file but this can generate token overuse that counts against the API rate limit.
Using different types of tokens complicates also plugin configuration.
This commit adds _'githubToken'_ property that is used both for reading and posting and deprecates _'readOnlyToken'_ and _'writeToken'_. It should be supplied by environmental variable that is configured in CI system.
As soon as new updated version is released _'githubToken'_ can be used instead of deprecated token properties.