### PR TITLE
Update documentation on new properties

### DIFF
--- a/src/integTest/groovy/org/shipkit/changelog/ChangelogPluginIntegTest.groovy
+++ b/src/integTest/groovy/org/shipkit/changelog/ChangelogPluginIntegTest.groovy
@@ -27,7 +27,7 @@ class ChangelogPluginIntegTest extends BaseSpecification {
             
             tasks.named("generateChangelog") {
                 previousRevision = "v3.3.10"
-                readOnlyToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
+                githubToken = "secret"
                 repository = "mockito/mockito"
             }
         """
@@ -67,8 +67,8 @@ class ChangelogPluginIntegTest extends BaseSpecification {
                 //The release version, default as below
                 version = project.version       
                 
-                //Token that enables querying GitHub, safe to check-in because it is read-only, *no default*              
-                readOnlyToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
+                //Token used for fetching tickets; same token is used for posting - should remain unexposed, *no default*
+                githubToken = "secret"
                 
                 //Repository to look for tickets, *no default*
                 repository = "mockito/mockito"

--- a/src/integTest/groovy/org/shipkit/gh/release/GitHubReleasePluginIntegTest.groovy
+++ b/src/integTest/groovy/org/shipkit/gh/release/GitHubReleasePluginIntegTest.groovy
@@ -25,7 +25,8 @@ class GitHubReleasePluginIntegTest extends BaseSpecification {
             tasks.named("githubRelease") {
                 repository = "shipkit/shipkit-changelog"
                 changelog = file("changelog.md")
-                writeToken = "secret"
+                newTagRevision = "ff2fb22b3bb2fb08164c126c0e2055d57dee441b"
+                githubToken = "secret"
             }
         """
 
@@ -55,8 +56,11 @@ class GitHubReleasePluginIntegTest extends BaseSpecification {
                 //The release tag, default as below
                 releaseName = "v" + project.version
                 
-                //GitHub write token, *no default*
-                writeToken = "secret"
+                //SHA of the revision from which release is created; *no default*
+                newTagRevision = "ff2fb22b3bb2fb08164c126c0e2055d57dee441b"
+                
+                //Github token used for posting to GH API, *no default*
+                githubToken = "secret"
             }
         """
 
@@ -73,7 +77,7 @@ class GitHubReleasePluginIntegTest extends BaseSpecification {
                 repository = "shipkit/shipkit-changelog"
                 changelog = file("changelog.md")
                 newTagRevision = "ff2fb22b3bb2fb08164c126c0e2055d57dee441b"
-                writeToken = "secret"
+                githubToken = "secret"
             }
         """
 


### PR DESCRIPTION
Recently new properties have been added to Shipkit Changelog plugin: 'newTagRevision' and 'githubToken'. This commit updates documentation with info on these properties.