### PR TITLE
Refactor scan publishing settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         fetch-depth: '0'
     - name: Run build
-      run: .\gradlew.bat build --scan --continue
+      run: .\gradlew.bat build --continue
 
   build:
 
@@ -35,13 +35,13 @@ jobs:
       with:
         fetch-depth: '0'
     - name: Run build
-      run: ./gradlew build --scan --continue
+      run: ./gradlew build --continue
     - name: Perform release (tagging, changelog, deployment to plugins.gradle.org)
       if: github.event_name == 'push'
           && github.ref == 'refs/heads/master'
           && github.repository == 'shipkit/shipkit-changelog'
           && !contains(toJSON(github.event.commits.*.message), '[skip release]')
-      run: ./gradlew githubRelease publishPlugins --scan
+      run: ./gradlew githubRelease publishPlugins
       env:
           # Gradle env variables docs: https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_environment_variables
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,9 @@ gradleEnterprise {
     buildScan {
         termsOfServiceUrl = "https://gradle.com/terms-of-service"
         termsOfServiceAgree = "yes"
-        uploadInBackground = System.getenv("CI") == null
+        if (System.getenv("CI")) {
+            publishAlways()
+            uploadInBackground = false
+        }
     }
 }


### PR DESCRIPTION
Resolves #56
Removed unnecessary _'--scan'_ argument from ci.yml workflow file. Now control of scan publishing is moved to _settings.gradle_ file and scan is set to be published only if build is run in CI. This change uses Gradle's Enterprise _'publishAlways()'_ which depends here on getting "CI" env var from CI and makes configuration simpler to set.