### PR TITLE
Rename GitHub referring classes/objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Encourage and help software developers set up their releases to be fully automat
 
 # Shipkit Changelog Gradle plugin
 
-Our plugin generates changelog based on commit history and GitHub pull requests/issues. 
-Optionally, the changelog content can be posted to GitHub Releases.
+Our plugin generates changelog based on commit history and Github pull requests/issues. 
+Optionally, the changelog content can be posted to Github Releases.
 This plugin is very small (<1kloc) and has a single dependency "com.eclipsesource.minimal-json:minimal-json:0.9.5".
 The dependency is very small (30kb), stable (no changes since 2017), and brings zero transitive dependencies.
 
@@ -75,9 +75,9 @@ Realistic example, also uses a sibling plugin [shipkit-auto-version](https://git
 
 ## Configuration reference
 
-### GitHub access tokens
+### Github access tokens
 
-The standard way to enable the automated tasks read/write to GitHub are the
+The standard way to enable the automated tasks read/write to Github are the
 [personal access tokens](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token#creating-a-token).
 Shipkit Changelog plugin needs a token to fetch tickets and post releases via GH REST API. 
 The token is set in the task configuration in \*.gradle file via `githubToken` property.
@@ -136,23 +136,23 @@ Just refer to the documentation of your CI system to learn what are its default 
 There are other Gradle plugins or tools that provide similar functionality:
 
 1. [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator)
-is a popular Ruby Gem (6K stars on GitHub) that generates changelog based on commits/pull requests
-but does not publish GitHub releases ([#56](https://github.com/github-changelog-generator/github-changelog-generator/issues/56)).
-Our plugin is a pure Gradle solution and it can publish a GitHub release.
+is a popular Ruby Gem (6K stars on Github) that generates changelog based on commits/pull requests
+but does not publish Github releases ([#56](https://github.com/github-changelog-generator/github-changelog-generator/issues/56)).
+Our plugin is a pure Gradle solution and it can publish a Github release.
 
-2. GitHub Action [Release Drafter](https://github.com/marketplace/actions/release-drafter)
+2. Github Action [Release Drafter](https://github.com/marketplace/actions/release-drafter)
 drafts the next release notes as pull requests are merged.
 This is a good option when the team wants to release on demand. 
 Our plugin is great for fully automated releases on every merged pull request.
 
 3. Gradle Plugin [git-changelog-gradle-plugin](https://github.com/tomasbjerre/git-changelog-gradle-plugin)
-seems like a nice plugin, maintained but not very popular (<50 stars on GitHub) and pulls in a lot of other dependencies
+seems like a nice plugin, maintained but not very popular (<50 stars on Github) and pulls in a lot of other dependencies
 ([#21](https://github.com/tomasbjerre/git-changelog-gradle-plugin/issues/21)).
 Our plugin is simpler, smaller and brings only one dependency (that is very small, simple and has no transitive dependencies).
 
 4. Semantic Release [semantic-release](https://github.com/semantic-release/semantic-release)
 is a npm module for fully automated "semantic" releases, with changelog generation.  
-It has impressive 10K stars on GitHub.
+It has impressive 10K stars on Github.
 Our plugin is less opinionated, smaller, simpler and a pure Gradle solution.
 
 Pick the best tool that work for you and start automating releases and changelog generation!
@@ -163,12 +163,12 @@ Pick the best tool that work for you and start automating releases and changelog
 
 1. Collect commits between 2 revisions
 2. Find ticket IDs based on '#' prefix in commit messages (e.g. looking for #1, #50, etc.)
-3. Use GitHub REST API to collect ticket information (issue or pull request) from GitHub
+3. Use Github REST API to collect ticket information (issue or pull request) from Github
 4. Create markdown file using the PR/issue titles 
 
-### Posting GitHub releases
+### Posting Github releases
 
-Uses GitHub REST API to post releases. 
+Uses Github REST API to post releases. 
 
 ## Usage
 
@@ -205,10 +205,10 @@ Complete task configuration
         //Working directory for running 'git' commands, default as below
         workingDir = project.projectDir                
         
-        //GitHub url, configure if you use GitHub Enterprise, default as below
+        //Github url, configure if you use Github Enterprise, default as below
         ghUrl = "https://github.com"
         
-        //GitHub API url, configure if you use GitHub Enterprise, default as below
+        //Github API url, configure if you use Github Enterprise, default as below
         ghApiUrl = "https://api.github.com"
         
         //The release date, the default is today date 
@@ -234,7 +234,7 @@ Complete task configuration
 ### 'org.shipkit.shipkit-gh-release'
 
 Basic task configuration
-(source: [GitHubReleasePluginIntegTest](https://github.com/shipkit/shipkit-changelog/blob/master/src/integTest/groovy/org/shipkit/gh/release/GitHubReleasePluginIntegTest.groovy))
+(source: [GithubReleasePluginIntegTest](https://github.com/shipkit/shipkit-changelog/blob/master/src/integTest/groovy/org/shipkit/gh/release/GithubReleasePluginIntegTest.groovy))
 
 ```groovy
     plugins {
@@ -250,7 +250,7 @@ Basic task configuration
 ```
 
 Complete task configuration
-(source: [GitHubReleasePluginIntegTest](https://github.com/shipkit/shipkit-changelog/blob/master/src/integTest/groovy/org/shipkit/gh/release/GitHubReleasePluginIntegTest.groovy))
+(source: [GithubReleasePluginIntegTest](https://github.com/shipkit/shipkit-changelog/blob/master/src/integTest/groovy/org/shipkit/gh/release/GithubReleasePluginIntegTest.groovy))
 
 ```groovy
     plugins {
@@ -258,7 +258,7 @@ Complete task configuration
     }
                 
     tasks.named("githubRelease") {
-        //GitHub API url, configure if you use GitHub Enterprise, default as below
+        //Github API url, configure if you use Github Enterprise, default as below
         ghApiUrl = "https://api.github.com"
         
         //Repository where to create a release, *no default*

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -5,9 +5,9 @@ gradlePlugin {
             id = 'org.shipkit.shipkit-changelog'
             implementationClass = 'org.shipkit.changelog.ChangelogPlugin'
         }
-        gitHubRelease {
+        githubRelease {
             id = 'org.shipkit.shipkit-gh-release'
-            implementationClass = 'org.shipkit.gh.release.GitHubReleasePlugin'
+            implementationClass = 'org.shipkit.gh.release.GithubReleasePlugin'
         }
     }
 }
@@ -18,12 +18,12 @@ pluginBundle {
     plugins {
         changelog {
             displayName = 'Shipkit changelog plugin'
-            description = 'Generates changelog based on ticked IDs found in commit messages and GitHub pull request information'
+            description = 'Generates changelog based on ticked IDs found in commit messages and Github pull request information'
             tags = ['ci', 'shipkit', 'changelog']
         }
-        gitHubRelease {
-            displayName = 'Shipkit GitHub release plugin'
-            description = 'Posts a release to GitHub using the REST API'
+        githubRelease {
+            displayName = 'Shipkit Github release plugin'
+            description = 'Posts a release to Github using the REST API'
             tags = ['ci', 'shipkit', 'github', 'release']
         }
     }

--- a/src/integTest/groovy/org/shipkit/changelog/ChangelogPluginIntegTest.groovy
+++ b/src/integTest/groovy/org/shipkit/changelog/ChangelogPluginIntegTest.groovy
@@ -40,10 +40,10 @@ class ChangelogPluginIntegTest extends BaseSpecification {
                 //Working directory for running 'git' commands, default as below
                 workingDir = project.projectDir                
                 
-                //GitHub url, configure if you use GitHub Enterprise, default as below
+                //Github url, configure if you use Github Enterprise, default as below
                 ghUrl = "https://github.com"
                 
-                //GitHub API url, configure if you use GitHub Enterprise, default as below
+                //Github API url, configure if you use Github Enterprise, default as below
                 ghApiUrl = "https://api.github.com"
                 
                 //The release date, the default is today date 
@@ -58,7 +58,7 @@ class ChangelogPluginIntegTest extends BaseSpecification {
                 //The release version, default as below
                 version = project.version       
                 
-                //Token that enables querying GitHub, safe to check-in because it is read-only, *no default*              
+                //Token that enables querying Github, safe to check-in because it is read-only, *no default*              
                 githubToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
                 
                 //Repository to look for tickets, *no default*

--- a/src/integTest/groovy/org/shipkit/gh/release/GithubReleasePluginIntegTest.groovy
+++ b/src/integTest/groovy/org/shipkit/gh/release/GithubReleasePluginIntegTest.groovy
@@ -6,9 +6,9 @@ import org.junit.rules.TemporaryFolder
 import org.shipkit.BaseSpecification
 
 /**
- * Smoke test, we don't want an integration test that actually posts to GitHub
+ * Smoke test, we don't want an integration test that actually posts to Github
  */
-class GitHubReleasePluginIntegTest extends BaseSpecification {
+class GithubReleasePluginIntegTest extends BaseSpecification {
 
     @Rule TemporaryFolder tmp = new TemporaryFolder()
 
@@ -41,7 +41,7 @@ class GitHubReleasePluginIntegTest extends BaseSpecification {
             }
                         
             tasks.named("githubRelease") {
-                //GitHub API url, configure if you use GitHub Enterprise, default as below
+                //Github API url, configure if you use Github Enterprise, default as below
                 ghApiUrl = "https://api.github.com"
                 
                 //Repository where to create a release, *no default*
@@ -85,7 +85,7 @@ class GitHubReleasePluginIntegTest extends BaseSpecification {
         def result = runner("githubRelease", "-s").buildAndFail()
 
         then: //fails because we don't have the credentials
-        result.output.contains """Unable to post release to GitHub.
+        result.output.contains """Unable to post release to Github.
     - url: https://api.github.com/repos/shipkit/shipkit-changelog/releases
     - release tag: v1.2.3
     - release name: v1.2.3

--- a/src/main/java/org/shipkit/changelog/ChangelogFormat.java
+++ b/src/main/java/org/shipkit/changelog/ChangelogFormat.java
@@ -17,7 +17,7 @@ public class ChangelogFormat {
      */
     public static String formatChangelog(Collection<String> contributors, Collection<Ticket> tickets, int commitCount,
                                          final String version, final String previousRev,
-                                         final String gitHubRepoUrl, final String date) {
+                                         final String githubRepoUrl, final String date) {
         String template = "@header@\n" +
                 "\n" +
                 "#### @version@\n" +
@@ -29,7 +29,7 @@ public class ChangelogFormat {
             put("version", version);
             put("date", date);
             put("commitCount", "" + commitCount);
-            put("repoUrl", gitHubRepoUrl);
+            put("repoUrl", githubRepoUrl);
             put("previousRev", previousRev);
             put("newRev", "v" + version);
             put("contributors", String.join(", ", contributors));

--- a/src/main/java/org/shipkit/changelog/ChangelogPlugin.java
+++ b/src/main/java/org/shipkit/changelog/ChangelogPlugin.java
@@ -21,7 +21,7 @@ public class ChangelogPlugin implements Plugin<Project> {
             t.setGhUrl("https://github.com");
             t.setWorkingDir(project.getProjectDir());
             t.setVersion("" + project.getVersion());
-            t.getOutputs().upToDateWhen(Specs.satisfyNone()); //depends on state of Git repo, GitHub, etc.
+            t.getOutputs().upToDateWhen(Specs.satisfyNone()); //depends on state of Git repo, Github, etc.
         });
     }
 }

--- a/src/main/java/org/shipkit/changelog/GenerateChangelogTask.java
+++ b/src/main/java/org/shipkit/changelog/GenerateChangelogTask.java
@@ -10,7 +10,7 @@ import java.io.File;
 import java.util.*;
 
 /**
- * Generates changelog based on the GitHub ticked ids found in commit messages.
+ * Generates changelog based on the Github ticked ids found in commit messages.
  */
 public class GenerateChangelogTask extends DefaultTask {
 
@@ -157,9 +157,9 @@ public class GenerateChangelogTask extends DefaultTask {
     }
 
     /**
-     * GitHub token used to pull GitHub issues.
+     * Github token used to pull Github issues.
      * The same token is used to post a new release:
-     * {@link org.shipkit.gh.release.GitHubReleaseTask#setGithubToken(String)}
+     * {@link org.shipkit.gh.release.GithubReleaseTask#setGithubToken(String)}
      */
     public void setGithubToken(String githubToken) {
         this.githubToken = githubToken;
@@ -183,10 +183,10 @@ public class GenerateChangelogTask extends DefaultTask {
 
         LOG.lifecycle("Fetching ticket info from {}/{} based on {} ids {}", ghApiUrl, repository, ticketIds.size(), ticketIds);
 
-        GitHubTicketFetcher fetcher = new GitHubTicketFetcher(ghApiUrl, repository, githubToken);
+        GithubTicketFetcher fetcher = new GithubTicketFetcher(ghApiUrl, repository, githubToken);
         Collection<Ticket> improvements = fetcher.fetchTickets(ticketIds);
 
-        LOG.lifecycle("Generating changelog based on {} tickets from GitHub", improvements.size());
+        LOG.lifecycle("Generating changelog based on {} tickets from Github", improvements.size());
         String changelog = ChangelogFormat.formatChangelog(contributors, improvements, commits.size(), version,
                 previousRevision, ghUrl + "/" + repository, date);
 

--- a/src/main/java/org/shipkit/changelog/GitHubListFetcher.java
+++ b/src/main/java/org/shipkit/changelog/GitHubListFetcher.java
@@ -7,15 +7,15 @@ import com.eclipsesource.json.JsonValue;
 import java.io.IOException;
 
 /**
- * This class contains standard operations for skim over GitHub API responses.
+ * This class contains standard operations for skim over Github API responses.
  */
-class GitHubListFetcher {
+class GithubListFetcher {
 
     private static final String NO_MORE_PAGES = "none";
     private final String githubToken;
     private String nextPageUrl;
 
-    GitHubListFetcher(String apiUrl, String repository, String githubToken) {
+    GithubListFetcher(String apiUrl, String repository, String githubToken) {
         this.githubToken = githubToken;
 
         // see API doc: https://developer.github.com/v3/issues/
@@ -39,11 +39,11 @@ class GitHubListFetcher {
      */
     JsonArray nextPage() throws IOException {
         if (!hasNextPage()) {
-            throw new IllegalStateException("GitHub API has no more issues to fetch. Did you run 'hasNextPage()' method?");
+            throw new IllegalStateException("Github API has no more issues to fetch. Did you run 'hasNextPage()' method?");
         }
 
-        GitHubApi api = new GitHubApi(githubToken);
-        GitHubApi.Response response = api.get(nextPageUrl);
+        GithubApi api = new GithubApi(githubToken);
+        GithubApi.Response response = api.get(nextPageUrl);
 
         nextPageUrl = getNextPageUrl(response.getLinkHeader());
 
@@ -61,7 +61,7 @@ class GitHubListFetcher {
             return NO_MORE_PAGES;
         }
 
-        // See GitHub API doc : https://developer.github.com/guides/traversing-with-pagination/
+        // See Github API doc : https://developer.github.com/guides/traversing-with-pagination/
         // Link: <https://api.github.com/repositories/6207167/issues?access_token=a0a4c0f41c200f7c653323014d6a72a127764e17&state=closed&filter=all&page=2>; rel="next",
         //       <https://api.github.com/repositories/62207167/issues?access_token=a0a4c0f41c200f7c653323014d6a72a127764e17&state=closed&filter=all&page=4>; rel="last"
         for (String linkRel : linkHeader.split(",")) {

--- a/src/main/java/org/shipkit/changelog/GithubApi.java
+++ b/src/main/java/org/shipkit/changelog/GithubApi.java
@@ -15,15 +15,15 @@ import java.util.Optional;
 import java.util.TimeZone;
 
 /**
- * Wrapper for making REST requests to GitHub API
+ * Wrapper for making REST requests to Github API
  */
-public class GitHubApi {
+public class GithubApi {
 
-    private static final Logger LOG = Logging.getLogger(GitHubApi.class);
+    private static final Logger LOG = Logging.getLogger(GithubApi.class);
 
     private final String authToken;
 
-    public GitHubApi(String authToken) {
+    public GithubApi(String authToken) {
         this.authToken = authToken;
     }
 
@@ -58,10 +58,10 @@ public class GitHubApi {
         String rateRemaining = c.getHeaderField("X-RateLimit-Remaining");
         String rateLimit = c.getHeaderField("X-RateLimit-Limit");
         //TODO instead of a lifecycle message, we should include the rate limiting information only when the request fails
-        LOG.lifecycle("GitHub API rate info => Remaining : " + rateRemaining + ", Limit : " + rateLimit + ", Reset at: " + resetInLocalTime);
+        LOG.lifecycle("Github API rate info => Remaining : " + rateRemaining + ", Limit : " + rateLimit + ", Reset at: " + resetInLocalTime);
 
         String linkHeader = c.getHeaderField("Link");
-        LOG.info("Next page 'Link' from GitHub: {}", linkHeader);
+        LOG.info("Next page 'Link' from Github: {}", linkHeader);
 
         String content = call(method, c);
         return new Response(content, linkHeader);

--- a/src/main/java/org/shipkit/changelog/GithubImprovementsJSON.java
+++ b/src/main/java/org/shipkit/changelog/GithubImprovementsJSON.java
@@ -3,12 +3,12 @@ package org.shipkit.changelog;
 import com.eclipsesource.json.JsonObject;
 
 /**
- * Provides means to parse JsonObjects returned from calling GitHub API.
+ * Provides means to parse JsonObjects returned from calling Github API.
  */
-class GitHubImprovementsJSON {
+class GithubImprovementsJSON {
 
     /**
-     * Parses GitHub JsonObject in accordance to the API (https://developer.github.com/v3/issues/)
+     * Parses Github JsonObject in accordance to the API (https://developer.github.com/v3/issues/)
      * @param issue
      */
     static Ticket toImprovement(JsonObject issue) {

--- a/src/main/java/org/shipkit/changelog/GithubTicketFetcher.java
+++ b/src/main/java/org/shipkit/changelog/GithubTicketFetcher.java
@@ -6,16 +6,16 @@ import com.eclipsesource.json.JsonValue;
 import java.util.*;
 import java.util.logging.Logger;
 
-class GitHubTicketFetcher {
+class GithubTicketFetcher {
 
-    private static final Logger LOG = Logger.getLogger(GitHubTicketFetcher.class.getName());
-    private final GitHubListFetcher fetcher;
+    private static final Logger LOG = Logger.getLogger(GithubTicketFetcher.class.getName());
+    private final GithubListFetcher fetcher;
 
-    GitHubTicketFetcher(String apiUrl, String repository, String githubToken) {
-        this(new GitHubListFetcher(apiUrl, repository, githubToken));
+    GithubTicketFetcher(String apiUrl, String repository, String githubToken) {
+        this(new GithubListFetcher(apiUrl, repository, githubToken));
     }
 
-    GitHubTicketFetcher(GitHubListFetcher fetcher) {
+    GithubTicketFetcher(GithubListFetcher fetcher) {
         this.fetcher = fetcher;
     }
 
@@ -24,7 +24,7 @@ class GitHubTicketFetcher {
         if (ticketIds.isEmpty()) {
             return out;
         }
-        LOG.info("Querying GitHub API for " + ticketIds.size() + " tickets.");
+        LOG.info("Querying Github API for " + ticketIds.size() + " tickets.");
 
         Queue<Long> tickets = queuedTicketNumbers(ticketIds);
 
@@ -37,7 +37,7 @@ class GitHubTicketFetcher {
                         page));
             }
         } catch (Exception e) {
-            throw new RuntimeException("Problems fetching " + ticketIds.size() + " tickets from GitHub", e);
+            throw new RuntimeException("Problems fetching " + ticketIds.size() + " tickets from Github", e);
         }
         return out;
     }
@@ -76,7 +76,7 @@ class GitHubTicketFetcher {
 
         List<Ticket> pagedTickets = new ArrayList<>();
         for (JsonValue issue : issues) {
-            Ticket i = GitHubImprovementsJSON.toImprovement(issue.asObject());
+            Ticket i = GithubImprovementsJSON.toImprovement(issue.asObject());
             if (tickets.remove(i.getId())) {
                 pagedTickets.add(i);
                 if (tickets.isEmpty()) {

--- a/src/main/java/org/shipkit/gh/release/GithubReleasePlugin.java
+++ b/src/main/java/org/shipkit/gh/release/GithubReleasePlugin.java
@@ -6,10 +6,10 @@ import org.gradle.api.Project;
 /**
  * The plugin, ideally with zero business logic, but only the Gradle integration code
  */
-public class GitHubReleasePlugin implements Plugin<Project> {
+public class GithubReleasePlugin implements Plugin<Project> {
 
     public void apply(Project project) {
-        project.getTasks().register("githubRelease", GitHubReleaseTask.class, t -> {
+        project.getTasks().register("githubRelease", GithubReleaseTask.class, t -> {
             t.setGhApiUrl("https://api.github.com");
             String tagName = "v" + project.getVersion();
             t.setReleaseTag(tagName);

--- a/src/main/java/org/shipkit/gh/release/GithubReleaseTask.java
+++ b/src/main/java/org/shipkit/gh/release/GithubReleaseTask.java
@@ -9,15 +9,15 @@ import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.TaskAction;
-import org.shipkit.changelog.GitHubApi;
+import org.shipkit.changelog.GithubApi;
 import org.shipkit.changelog.IOUtil;
 
 import java.io.File;
 import java.io.IOException;
 
-public class GitHubReleaseTask extends DefaultTask {
+public class GithubReleaseTask extends DefaultTask {
 
-    private final static Logger LOG = Logging.getLogger(GitHubReleaseTask.class);
+    private final static Logger LOG = Logging.getLogger(GithubReleaseTask.class);
 
     private String ghApiUrl = null;
     private String repository = null;
@@ -117,7 +117,7 @@ public class GitHubReleaseTask extends DefaultTask {
 
     /**
      * Property required to specify revision for the new tag.
-     * The property's value is passed to GitHub API's
+     * The property's value is passed to Github API's
      * 'target_commitish' parameter in {@link #postRelease()} method.
      */
     public void setNewTagRevision(String newTagRevision) {
@@ -134,13 +134,13 @@ public class GitHubReleaseTask extends DefaultTask {
         String releaseNotesTxt = IOUtil.readFully(changelog);
         body.add("body", releaseNotesTxt);
 
-        GitHubApi gitHubApi = new GitHubApi(githubToken);
+        GithubApi githubApi = new GithubApi(githubToken);
         try {
-            String response = gitHubApi.post(url, body.toString());
+            String response = githubApi.post(url, body.toString());
             String htmlUrl = Json.parse(response).asObject().getString("html_url", "");
-            LOG.lifecycle("Posted release to GitHub: " + htmlUrl);
+            LOG.lifecycle("Posted release to Github: " + htmlUrl);
         } catch (IOException e) {
-            throw new GradleException("Unable to post release to GitHub.\n" +
+            throw new GradleException("Unable to post release to Github.\n" +
                     "  - url: " + url + "\n" +
                     "  - release tag: " + releaseTag + "\n" +
                     "  - release name: " + releaseName + "\n" +

--- a/src/test/groovy/org/shipkit/changelog/GithubImprovementsJSONTest.groovy
+++ b/src/test/groovy/org/shipkit/changelog/GithubImprovementsJSONTest.groovy
@@ -3,14 +3,14 @@ package org.shipkit.changelog
 import com.eclipsesource.json.Json
 import spock.lang.Specification
 
-class GitHubImprovementsJSONTest extends Specification {
+class GithubImprovementsJSONTest extends Specification {
 
     def "parses issue"() {
         def issue = Json.parse('{"number": 100, "html_url": "http://issues/100", "title": "Some bugfix"}')
                 .asObject()
 
         when:
-        def i = GitHubImprovementsJSON.toImprovement(issue)
+        def i = GithubImprovementsJSON.toImprovement(issue)
 
         then:
         i.id == 100L

--- a/src/test/groovy/org/shipkit/changelog/GithubTicketFetcherIntegTest.groovy
+++ b/src/test/groovy/org/shipkit/changelog/GithubTicketFetcherIntegTest.groovy
@@ -2,10 +2,10 @@ package org.shipkit.changelog
 
 import spock.lang.Specification
 
-class GitHubTicketFetcherIntegTest extends Specification {
+class GithubTicketFetcherIntegTest extends Specification {
 
-    def "fetches from GitHub"() {
-        def fetcher = new GitHubTicketFetcher("https://api.github.com", "mockito/mockito",
+    def "fetches from Github"() {
+        def fetcher = new GithubTicketFetcher("https://api.github.com", "mockito/mockito",
                 "a0a4c0f41c200f7c653323014d6a72a127764e17")
 
         when:
@@ -18,8 +18,8 @@ class GitHubTicketFetcherIntegTest extends Specification {
 {id=1922, title='[build] add ben-manes dependency upgrade finder', url='https://github.com/mockito/mockito/pull/1922'}"""
     }
 
-    def "fetches from GitHub without token"() {
-        def fetcher = new GitHubTicketFetcher("https://api.github.com", "mockito/mockito", null)
+    def "fetches from Github without token"() {
+        def fetcher = new GithubTicketFetcher("https://api.github.com", "mockito/mockito", null)
 
         when:
         //TODO: we need to query a repo that is dedicated for this test and validate that pagination works

--- a/src/test/groovy/org/shipkit/changelog/GithubTicketFetcherTest.groovy
+++ b/src/test/groovy/org/shipkit/changelog/GithubTicketFetcherTest.groovy
@@ -4,10 +4,10 @@ import com.eclipsesource.json.Json
 import com.eclipsesource.json.JsonArray
 import spock.lang.Specification
 
-class GitHubTicketFetcherTest extends Specification {
+class GithubTicketFetcherTest extends Specification {
 
-    def listFetcher = Mock(GitHubListFetcher)
-    def fetcher = new GitHubTicketFetcher(listFetcher)
+    def listFetcher = Mock(GithubListFetcher)
+    def fetcher = new GithubTicketFetcher(listFetcher)
 
     def "empty tickets"() {
         expect:


### PR DESCRIPTION
Applying consistent naming convention for classes/objects that refer to GitHub (#65).
This commit renames _'GitHub' / 'gitHub'_ => _'Github' / 'github'_