### PR TITLE
Improved error message

### DIFF
--- a/src/integTest/groovy/org/shipkit/gh/release/GithubReleasePluginIntegTest.groovy
+++ b/src/integTest/groovy/org/shipkit/gh/release/GithubReleasePluginIntegTest.groovy
@@ -86,11 +86,13 @@ class GithubReleasePluginIntegTest extends BaseSpecification {
 
         then: //fails because we don't have the credentials
         result.output.contains """Unable to post release to Github.
-    - url: https://api.github.com/repos/shipkit/shipkit-changelog/releases
-    - release tag: v1.2.3
-    - release name: v1.2.3
-    - token: sec...
-    - content:
-  Spanking new release!"""
+  * url: https://api.github.com/repos/shipkit/shipkit-changelog/releases
+  * release tag: v1.2.3
+  * release name: v1.2.3
+  * token: sec...
+  * content:
+Spanking new release!
+
+  * underlying problem:"""
     }
 }

--- a/src/main/java/org/shipkit/gh/release/GithubReleaseTask.java
+++ b/src/main/java/org/shipkit/gh/release/GithubReleaseTask.java
@@ -141,11 +141,14 @@ public class GithubReleaseTask extends DefaultTask {
             LOG.lifecycle("Posted release to Github: " + htmlUrl);
         } catch (IOException e) {
             throw new GradleException("Unable to post release to Github.\n" +
-                    "  - url: " + url + "\n" +
-                    "  - release tag: " + releaseTag + "\n" +
-                    "  - release name: " + releaseName + "\n" +
-                    "  - token: " + githubToken.substring(0, 3) + "...\n" +
-                    "  - content:\n" + releaseNotesTxt + "\n"
+                    "  * url: " + url + "\n" +
+                    "  * release tag: " + releaseTag + "\n" +
+                    "  * release name: " + releaseName + "\n" +
+                    "  * token: " + githubToken.substring(0, 3) + "...\n" +
+                    "  * content:\n" + releaseNotesTxt + "\n\n" +
+                    "  * underlying problem: " + e.getMessage() + "\n" +
+                    "  * troubleshooting: please run Gradle with '-s' to see the full stack trace or inspect the build scan\n" +
+                    "  * thank you for using Shipkit!"
                     , e);
         }
     }


### PR DESCRIPTION
Now it is easier to deduct the problem by just looking at the default output from a failing build.

Previously:

```
> Unable to post release to Github.
    - url: https://api.github.com/repos/shipkit/shipkit-changelog/releases
    - release tag: v0.2.15
    - release name: v0.2.15
    - token: d19...
    - content:
  <sup><sup>*Changelog generated by [Shipkit Changelog Gradle Plugin](https://github.com/shipkit/shipkit-changelog)*</sup></sup>
  
  #### 0.2.15
   - 2021-01-03 - [0 commit(s)](https://github.com/shipkit/shipkit-changelog/compare/v0.2.15...v0.2.15) by 
   - No notable improvements. No pull requests (issues) were referenced from commits.
```

After this pr:

```
> Unable to post release to Github.
    * url: https://api.github.com/repos/shipkit/shipkit-changelog/releases
    * release tag: v0.2.15
    * release name: v0.2.15
    * token: d19...
    * content:
  <sup><sup>*Changelog generated by [Shipkit Changelog Gradle Plugin](https://github.com/shipkit/shipkit-changelog)*</sup></sup>
  
  #### 0.2.15
   - 2021-01-03 - [0 commit(s)](https://github.com/shipkit/shipkit-changelog/compare/v0.2.15...v0.2.15) by 
   - No notable improvements. No pull requests (issues) were referenced from commits.
  
    * underlying problem: POST https://api.github.com/repos/shipkit/shipkit-changelog/releases failed, response code = 422, response body:
  {"message":"Validation Failed","errors":[{"resource":"Release","code":"already_exists","field":"tag_name"}],"documentation_url":"https://docs.github.com/rest/reference/repos#create-a-release"}
    * troubleshooting: please run Gradle with '-s' to see the full stack trace or inspect the build scan
    * thank you for using Shipkit!
```