### PR TITLE
Rename GitHub referring classes/objects; 'gh' => 'github'

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ tasks.named("generateChangelog") {
     previousRevision = "v0.0.1"
     repository = "shipkit/shipkit-changelog"
     githubToken = System.getenv("GITHUB_TOKEN") // using env var to avoid checked-in secrets
-    newTagRevision = System.getenv("GITHUB_SHA")   // using an env var automatically exported by GH action
+    newTagRevision = System.getenv("GITHUB_SHA")   // using an env var automatically exported by Github Actions
 }
 
 ```
@@ -69,7 +69,7 @@ Realistic example, also uses a sibling plugin [shipkit-auto-version](https://git
         repository = "shipkit/shipkit-changelog"
         changelog = tasks.named("generateChangelog").get().outputFile
         githubToken = System.getenv("GITHUB_TOKEN") // using env var to avoid checked-in secrets
-        newTagRevision = System.getenv("GITHUB_SHA")   // using an env var automatically exported by GH action
+        newTagRevision = System.getenv("GITHUB_SHA")   // using an env var automatically exported by Github Actions
     }
 ```
 
@@ -79,12 +79,12 @@ Realistic example, also uses a sibling plugin [shipkit-auto-version](https://git
 
 The standard way to enable the automated tasks read/write to Github are the
 [personal access tokens](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token#creating-a-token).
-Shipkit Changelog plugin needs a token to fetch tickets and post releases via GH REST API. 
+Shipkit Changelog plugin needs a token to fetch tickets and post releases via Github REST API. 
 The token is set in the task configuration in \*.gradle file via `githubToken` property.
-When creating a new token using GH UI, make sure to select the `repo/public_repo` *scope*
+When creating a new token using Github UI, make sure to select the `repo/public_repo` *scope*
 ([more info on scopes](https://docs.github.com/en/free-pro-team@latest/developers/apps/scopes-for-oauth-apps)).
 
-When using GH Actions then you can use the built-in `GITHUB_TOKEN` secret.
+When using Github Actions then you can use the built-in `GITHUB_TOKEN` secret.
 You can pass it via an environment variable:
 
 ```yaml
@@ -94,7 +94,7 @@ You can pass it via an environment variable:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 ```
 
-Read more about GH Action's [GITHUB_TOKEN](https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow).
+Read more about Github Action's [GITHUB_TOKEN](https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow).
 In Shipkit Changelog plugin the `githubToken` property should be supplied by the env variable to keep things safe.
 The token grants write access to the repository and it ***should not*** be exposed / checked-in.
 
@@ -102,7 +102,7 @@ The token grants write access to the repository and it ***should not*** be expos
 
 CI systems are often configured by default to perform Git fetch with minimum amount of commits.
 However, our changelog plugin needs commits in order to generate the release notes.
-When using GH actions, please configure your checkout action to fetch the entire history.
+When using Github Actions, please configure your checkout action to fetch the entire history.
 Based on our tests in Mockito project, the checkout of the *entire* Mockito history (dating 2008)
 has negligible performance implication (adds ~2 secs to the checkout).
 
@@ -115,11 +115,11 @@ has negligible performance implication (adds ~2 secs to the checkout).
 ### Target revision
 
 For proper release tagging the `newTagRevision` property needs to be set.
-This property is set with the SHA of the commit that will be tagged when GH release is created.
+This property is set with the SHA of the commit that will be tagged when Github release is created.
 Recommended way to do this is to use your CI system's built-in env variable that exposes the revision the CI is building.
-GH actions expose `GITHUB_SHA` and hence we are using it in the code samples.
-You can read more about all [default env variables](https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables) exposed by GH actions.
-Note that you can use *any* CI system, not necessarily GH actions.
+Github Actions expose `GITHUB_SHA` and hence we are using it in the code samples.
+You can read more about all [default env variables](https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables) exposed by Github Actions.
+Note that you can use *any* CI system, not necessarily Github Actions.
 Just refer to the documentation of your CI system to learn what are its default env variables.
 
 ## Customers / sample projects
@@ -186,7 +186,7 @@ Basic task configuration
         previousRevision = "v3.3.10"
         repository = "mockito/mockito"
         githubToken = System.getenv("GITHUB_TOKEN") // using env var to avoid checked-in secrets
-        newTagRevision = System.getenv("GITHUB_SHA")   // using an env var automatically exported by GH action
+        newTagRevision = System.getenv("GITHUB_SHA")   // using an env var automatically exported by Github Actions
     }
 ```
 
@@ -206,10 +206,10 @@ Complete task configuration
         workingDir = project.projectDir                
         
         //Github url, configure if you use Github Enterprise, default as below
-        ghUrl = "https://github.com"
+        githubUrl = "https://github.com"
         
         //Github API url, configure if you use Github Enterprise, default as below
-        ghApiUrl = "https://api.github.com"
+        githubApiUrl = "https://api.github.com"
         
         //The release date, the default is today date 
         date = "2020-06-06"
@@ -245,7 +245,7 @@ Basic task configuration
         repository = "shipkit/shipkit-changelog"
         changelog = file("changelog.md")
         githubToken = System.getenv("GITHUB_TOKEN") // using env var to avoid checked-in secrets
-        newTagRevision = System.getenv("GITHUB_SHA")   // using an env var automatically exported by GH action        
+        newTagRevision = System.getenv("GITHUB_SHA")   // using an env var automatically exported by Github Actions        
     }
 ```
 
@@ -259,7 +259,7 @@ Complete task configuration
                 
     tasks.named("githubRelease") {
         //Github API url, configure if you use Github Enterprise, default as below
-        ghApiUrl = "https://api.github.com"
+        githubApiUrl = "https://api.github.com"
         
         //Repository where to create a release, *no default*
         repository = "shipkit/shipkit-changelog"
@@ -273,11 +273,11 @@ Complete task configuration
         //The release tag, default as below
         releaseName = "v" + project.version      
 
-        //Github token used for posting to GH API, *no default*
+        //Github token used for posting to Github API, *no default*
         githubToken = System.getenv("GITHUB_TOKEN") // using env var to avoid checked-in secrets
         
         //SHA of the revision from which release is created; *no default*
-        newTagRevision = System.getenv("GITHUB_SHA")   // using an env var automatically exported by GH action        
+        newTagRevision = System.getenv("GITHUB_SHA")   // using an env var automatically exported by Github Actions        
     }
 ``` 
 

--- a/src/integTest/groovy/org/shipkit/changelog/ChangelogPluginIntegTest.groovy
+++ b/src/integTest/groovy/org/shipkit/changelog/ChangelogPluginIntegTest.groovy
@@ -41,10 +41,10 @@ class ChangelogPluginIntegTest extends BaseSpecification {
                 workingDir = project.projectDir                
                 
                 //Github url, configure if you use Github Enterprise, default as below
-                ghUrl = "https://github.com"
+                githubUrl = "https://github.com"
                 
                 //Github API url, configure if you use Github Enterprise, default as below
-                ghApiUrl = "https://api.github.com"
+                githubApiUrl = "https://api.github.com"
                 
                 //The release date, the default is today date 
                 date = "2020-06-06"

--- a/src/integTest/groovy/org/shipkit/gh/release/GithubReleasePluginIntegTest.groovy
+++ b/src/integTest/groovy/org/shipkit/gh/release/GithubReleasePluginIntegTest.groovy
@@ -42,7 +42,7 @@ class GithubReleasePluginIntegTest extends BaseSpecification {
                         
             tasks.named("githubRelease") {
                 //Github API url, configure if you use Github Enterprise, default as below
-                ghApiUrl = "https://api.github.com"
+                githubApiUrl = "https://api.github.com"
                 
                 //Repository where to create a release, *no default*
                 repository = "shipkit/shipkit-changelog"
@@ -59,7 +59,7 @@ class GithubReleasePluginIntegTest extends BaseSpecification {
                 //SHA of the revision from which release is created; *no default*
                 newTagRevision = "ff2fb22b3bb2fb08164c126c0e2055d57dee441b"
                 
-                //Github token used for posting to GH API, *no default*
+                //Github token used for posting to Github API, *no default*
                 githubToken = "secret"
             }
         """

--- a/src/main/java/org/shipkit/changelog/ChangelogPlugin.java
+++ b/src/main/java/org/shipkit/changelog/ChangelogPlugin.java
@@ -17,8 +17,8 @@ public class ChangelogPlugin implements Plugin<Project> {
             t.setRevision("HEAD");
             t.setDate(DateUtil.formatDate(new Date()));
             t.setOutputFile(new File(project.getBuildDir(), "changelog.md"));
-            t.setGhApiUrl("https://api.github.com");
-            t.setGhUrl("https://github.com");
+            t.setGithubApiUrl("https://api.github.com");
+            t.setGithubUrl("https://github.com");
             t.setWorkingDir(project.getProjectDir());
             t.setVersion("" + project.getVersion());
             t.getOutputs().upToDateWhen(Specs.satisfyNone()); //depends on state of Git repo, Github, etc.

--- a/src/main/java/org/shipkit/changelog/GenerateChangelogTask.java
+++ b/src/main/java/org/shipkit/changelog/GenerateChangelogTask.java
@@ -16,11 +16,11 @@ public class GenerateChangelogTask extends DefaultTask {
 
     private final static Logger LOG = Logging.getLogger(GenerateChangelogTask.class);
 
-    private String ghUrl;
+    private String githubUrl;
     private File outputFile;
     private File workingDir;
     private String githubToken;
-    private String ghApiUrl;
+    private String githubApiUrl;
     private String repository;
     private String previousRevision;
     private String version;
@@ -40,12 +40,12 @@ public class GenerateChangelogTask extends DefaultTask {
     }
 
     @Input
-    public String getGhUrl() {
-        return ghUrl;
+    public String getGithubUrl() {
+        return githubUrl;
     }
 
-    public void setGhUrl(String ghUrl) {
-        this.ghUrl = ghUrl;
+    public void setGithubUrl(String githubUrl) {
+        this.githubUrl = githubUrl;
     }
 
     /**
@@ -104,12 +104,12 @@ public class GenerateChangelogTask extends DefaultTask {
     }
 
     @Input
-    public String getGhApiUrl() {
-        return ghApiUrl;
+    public String getGithubApiUrl() {
+        return githubApiUrl;
     }
 
-    public void setGhApiUrl(String ghApiUrl) {
-        this.ghApiUrl = ghApiUrl;
+    public void setGithubApiUrl(String githubApiUrl) {
+        this.githubApiUrl = githubApiUrl;
     }
 
     @OutputFile
@@ -181,14 +181,14 @@ public class GenerateChangelogTask extends DefaultTask {
             contributors.add(c.getAuthor());
         }
 
-        LOG.lifecycle("Fetching ticket info from {}/{} based on {} ids {}", ghApiUrl, repository, ticketIds.size(), ticketIds);
+        LOG.lifecycle("Fetching ticket info from {}/{} based on {} ids {}", githubApiUrl, repository, ticketIds.size(), ticketIds);
 
-        GithubTicketFetcher fetcher = new GithubTicketFetcher(ghApiUrl, repository, githubToken);
+        GithubTicketFetcher fetcher = new GithubTicketFetcher(githubApiUrl, repository, githubToken);
         Collection<Ticket> improvements = fetcher.fetchTickets(ticketIds);
 
         LOG.lifecycle("Generating changelog based on {} tickets from Github", improvements.size());
         String changelog = ChangelogFormat.formatChangelog(contributors, improvements, commits.size(), version,
-                previousRevision, ghUrl + "/" + repository, date);
+                previousRevision, githubUrl + "/" + repository, date);
 
         LOG.lifecycle("Saving changelog to file: {}", outputFile);
         IOUtil.writeFile(outputFile, changelog.trim());

--- a/src/main/java/org/shipkit/gh/release/GithubReleasePlugin.java
+++ b/src/main/java/org/shipkit/gh/release/GithubReleasePlugin.java
@@ -10,7 +10,7 @@ public class GithubReleasePlugin implements Plugin<Project> {
 
     public void apply(Project project) {
         project.getTasks().register("githubRelease", GithubReleaseTask.class, t -> {
-            t.setGhApiUrl("https://api.github.com");
+            t.setGithubApiUrl("https://api.github.com");
             String tagName = "v" + project.getVersion();
             t.setReleaseTag(tagName);
             t.setReleaseName(tagName);

--- a/src/main/java/org/shipkit/gh/release/GithubReleaseTask.java
+++ b/src/main/java/org/shipkit/gh/release/GithubReleaseTask.java
@@ -19,7 +19,7 @@ public class GithubReleaseTask extends DefaultTask {
 
     private final static Logger LOG = Logging.getLogger(GithubReleaseTask.class);
 
-    private String ghApiUrl = null;
+    private String githubApiUrl = null;
     private String repository = null;
     private String releaseName = null;
     private String releaseTag = null;
@@ -28,12 +28,12 @@ public class GithubReleaseTask extends DefaultTask {
     private String newTagRevision = null;
 
     @Input
-    public String getGhApiUrl() {
-        return ghApiUrl;
+    public String getGithubApiUrl() {
+        return githubApiUrl;
     }
 
-    public void setGhApiUrl(String ghApiUrl) {
-        this.ghApiUrl = ghApiUrl;
+    public void setGithubApiUrl(String githubApiUrl) {
+        this.githubApiUrl = githubApiUrl;
     }
 
     @Input
@@ -98,7 +98,7 @@ public class GithubReleaseTask extends DefaultTask {
     }
 
     /**
-     * Token required by GH API to post a new release.
+     * Token required by Github API to post a new release.
      * This token should have *write* permission to the repo.
      *
      * @param githubToken token with write permissions
@@ -125,7 +125,7 @@ public class GithubReleaseTask extends DefaultTask {
     }
 
     @TaskAction public void postRelease() {
-        String url = ghApiUrl + "/repos/" + repository + "/releases";
+        String url = githubApiUrl + "/repos/" + repository + "/releases";
 
         JsonObject body = new JsonObject();
         body.add("tag_name", releaseTag);


### PR DESCRIPTION
Applying consistent naming convention for classes/objects that refer to GitHub (#65).
This commit renames 'GH'/'gh' => 'Github'/'github'