### PR TITLE
New major version 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CI](https://github.com/shipkit/shipkit-changelog/workflows/CI/badge.svg)](https://github.com/shipkit/shipkit-changelog/actions)
-[![Gradle Portal](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/org/shipkit/shipkit-changelog/maven-metadata.xml.svg?label=Gradle%20Plugins)](https://plugins.gradle.org/plugin/org.shipkit.shipkit-changelog)
+[![Gradle Plugin Portal](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/org/shipkit/shipkit-changelog/maven-metadata.xml.svg?label=Version)](https://plugins.gradle.org/plugin/org.shipkit.shipkit-changelog)
 
 # Shipkit
 
@@ -32,9 +32,12 @@ Also check out [shipkit-auto-version](https://github.com/shipkit/shipkit-auto-ve
 
 ## Basic usage
 
+Use the *highest* version available in the Gradle Plugin Portal: 
+[![Gradle Plugin Portal](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/org/shipkit/shipkit-changelog/maven-metadata.xml.svg?label=shipkit-changelog)](https://plugins.gradle.org/plugin/org.shipkit.shipkit-changelog)
+
 ```groovy
 plugins {  
-    id 'org.shipkit.shipkit-changelog'
+    id "org.shipkit.shipkit-changelog" version "x.y.z"
 }
 
 tasks.named("generateChangelog") {
@@ -49,13 +52,14 @@ tasks.named("generateChangelog") {
 ## Realistic example
 
 Realistic example, also uses a sibling plugin [shipkit-auto-version](https://github.com/shipkit/shipkit-auto-version) plugin
-(source: [gradle/release.gradle](https://github.com/shipkit/shipkit-changelog/blob/master/gradle/release.gradle))
+at version: [![Gradle Plugin Portal](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/org/shipkit/shipkit-auto-version/maven-metadata.xml.svg?label=shipkit-auto-version)](https://plugins.gradle.org/plugin/org.shipkit.shipkit-auto-version).
+Code sample source: [gradle/release.gradle](https://github.com/shipkit/shipkit-changelog/blob/master/gradle/release.gradle)
 
 ```groovy
     plugins {
-        id 'org.shipkit.shipkit-changelog'
-        id 'org.shipkit.shipkit-github-release'
-        id 'org.shipkit.shipkit-auto-version'
+        id 'org.shipkit.shipkit-changelog' version "x.y.z"
+        id 'org.shipkit.shipkit-github-release' version "x.y.z"
+        id 'org.shipkit.shipkit-auto-version' version "x.y.z"
     }
 
     tasks.named("generateChangelog") {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "org.shipkit:shipkit-auto-version:0.+"
+        classpath "org.shipkit:shipkit-auto-version:1.+"
         classpath "org.shipkit:shipkit-changelog:0.+"
         classpath "com.gradle.publish:plugin-publish-plugin:0.12.0"
     }

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -5,11 +5,6 @@ gradlePlugin {
             id = 'org.shipkit.shipkit-changelog'
             implementationClass = 'org.shipkit.changelog.ChangelogPlugin'
         }
-        githubReleaseDeprecated {
-            //TODO please remove deprecated plugin after we complete the rename, see #65
-            id = 'org.shipkit.shipkit-gh-release'
-            implementationClass = 'org.shipkit.github.release.GithubReleasePlugin'
-        }
         githubRelease {
             id = 'org.shipkit.shipkit-github-release'
             implementationClass = 'org.shipkit.github.release.GithubReleasePlugin'
@@ -25,11 +20,6 @@ pluginBundle {
             displayName = 'Shipkit changelog plugin'
             description = 'Generates changelog based on ticked IDs found in commit messages and Github pull request information'
             tags = ['ci', 'shipkit', 'changelog']
-        }
-        githubReleaseDeprecated {
-            displayName = 'Deprecated, please use org.shipkit.shipkit-github-release'
-            description = 'Deprecated, please use org.shipkit.shipkit-github-release'
-            tags = ['ci', 'shipkit', 'github', 'release']
         }
         githubRelease {
             displayName = 'Shipkit Github release plugin'

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=0.2.*
+version=1.1.*


### PR DESCRIPTION
- removed deprecated plugin
- bumped version to major (need to use 1.1.* due to #65)
- bumped version of auto-version plugin