### PR TITLE
Allow empty githubToken for generateChangelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Complete task configuration
         //Repository to look for tickets, *no default*
         repository = "mockito/mockito"
         
-        //Token used for fetching tickets, *no default*
+        //Token used for fetching tickets, *empty*
         githubToken = System.getenv("GITHUB_TOKEN") // using env var to avoid checked-in secrets 
     }              
 ```

--- a/src/main/java/org/shipkit/changelog/GenerateChangelogTask.java
+++ b/src/main/java/org/shipkit/changelog/GenerateChangelogTask.java
@@ -153,6 +153,7 @@ public class GenerateChangelogTask extends DefaultTask {
      * See {@link #setGithubToken(String)}
      */
     @Input
+    @Optional
     public String getGithubToken() {
         return githubToken;
     }


### PR DESCRIPTION
We did the same for old property #47 

On GitHub Actions we can use auto generated token - `GITHUB_TOKEN`
When we use `GITHUB_TOKEN` we don't have token outside CI system, so running `generateChangelog` task on local environment is not possible.

In this situation for public repository we can allow run `generateChangelog` locally without token.

When this field is empty for local development, we are limited to 60 requests per hour.  
