### PR TITLE
Remove duplicated code in test

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Basic task configuration
 ```
 
 Complete task configuration
-(source: [GithubReleasePluginIntegTest](https://github.com/shipkit/shipkit-changelog/blob/master/src/integTest/groovy/org/shipkit/github/release/GithubReleasePluginIntegTest.groovy))
+(source: [GithubReleasePluginIntegTest](https://github.com/shipkit/shipkit-changelog/blob/master/src/integTest/groovy/org/shipkit/gh/release/GithubReleasePluginIntegTest.groovy))
 
 ```groovy
     plugins {

--- a/README.md
+++ b/README.md
@@ -280,11 +280,8 @@ Complete task configuration
         //The file with changelog (release notes), *no default*
         changelog = file("changelog.md")
         
-        //The name of the release name, default as below
+        //The name of the release, default as below
         releaseName = "v" + project.version
-        
-        //The release tag, default as below
-        releaseName = "v" + project.version      
 
         //Github token used for posting to Github API, *no default*
         githubToken = System.getenv("GITHUB_TOKEN") // using env var to avoid checked-in secrets

--- a/src/integTest/groovy/org/shipkit/gh/release/GithubReleasePluginIntegTest.groovy
+++ b/src/integTest/groovy/org/shipkit/gh/release/GithubReleasePluginIntegTest.groovy
@@ -50,10 +50,7 @@ class GithubReleasePluginIntegTest extends BaseSpecification {
                 //The file with changelog (release notes), *no default*
                 changelog = file("changelog.md")
                 
-                //The name of the release name, default as below
-                releaseName = "v" + project.version
-                
-                //The release tag, default as below
+                //The name of the release, default as below
                 releaseName = "v" + project.version
                 
                 //SHA of the revision from which release is created; *no default*


### PR DESCRIPTION
There is duplicated code in GithubReleasePluginIntegTest and documentation. To keep code clear, the duplication should be removed.
Also link to the test is fixed with this PR (there was a mistake in the path).