### PR TITLE
Make workingDir property internal and only expose the .git directory

### DIFF
--- a/src/main/java/org/shipkit/changelog/GenerateChangelogTask.java
+++ b/src/main/java/org/shipkit/changelog/GenerateChangelogTask.java
@@ -144,15 +144,20 @@ public class GenerateChangelogTask extends DefaultTask {
         return workingDir;
     }
 
+    @Optional
     @InputDirectory
     @PathSensitive(PathSensitivity.RELATIVE)
     public File getGitDir() {
+        return provideGitDir(workingDir);
+    }
+
+    static File provideGitDir(File workingDir) {
         if (workingDir == null) {
             return null;
         }
-        else {
-            return new File(workingDir, ".git");
-        }
+
+        File gitDir = new File(workingDir, ".git");
+        return gitDir.isDirectory() ? gitDir : null;
     }
 
     public void setWorkingDir(File workingDir) {

--- a/src/main/java/org/shipkit/changelog/GenerateChangelogTask.java
+++ b/src/main/java/org/shipkit/changelog/GenerateChangelogTask.java
@@ -139,9 +139,20 @@ public class GenerateChangelogTask extends DefaultTask {
         this.outputFile = outputFile;
     }
 
-    @InputDirectory
+    @Internal
     public File getWorkingDir() {
         return workingDir;
+    }
+
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public File getGitDir() {
+        if (workingDir == null) {
+            return null;
+        }
+        else {
+            return new File(workingDir, ".git");
+        }
     }
 
     public void setWorkingDir(File workingDir) {

--- a/src/test/groovy/org/shipkit/changelog/ChangelogPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/changelog/ChangelogPluginTest.groovy
@@ -12,13 +12,6 @@ class ChangelogPluginTest extends Specification {
         project.plugins.apply(ChangelogPlugin)
 
         then:
-        GenerateChangelogTask t = project.tasks.generateChangelog
-        t.gitDir
-
-        when:
-        t.workingDir = null
-
-        then:
-        !t.gitDir
+        project.tasks.generateChangelog
     }
 }

--- a/src/test/groovy/org/shipkit/changelog/ChangelogPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/changelog/ChangelogPluginTest.groovy
@@ -12,6 +12,13 @@ class ChangelogPluginTest extends Specification {
         project.plugins.apply(ChangelogPlugin)
 
         then:
-        project.tasks.generateChangelog
+        GenerateChangelogTask t = project.tasks.generateChangelog
+        t.gitDir
+
+        when:
+        t.workingDir = null
+
+        then:
+        !t.gitDir
     }
 }

--- a/src/test/groovy/org/shipkit/changelog/GenerateChangelogTaskTest.groovy
+++ b/src/test/groovy/org/shipkit/changelog/GenerateChangelogTaskTest.groovy
@@ -1,0 +1,22 @@
+package org.shipkit.changelog
+
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+import static org.shipkit.changelog.GenerateChangelogTask.provideGitDir
+
+class GenerateChangelogTaskTest extends Specification {
+
+    @Rule TemporaryFolder tmp = new TemporaryFolder()
+
+    def "getGitDir is safe"() {
+        expect:
+        provideGitDir(null) == null
+        provideGitDir(new File("missing")) == null
+
+        and:
+        def gitDir = tmp.newFolder(".git")
+        provideGitDir(gitDir.parentFile) == gitDir
+    }
+}


### PR DESCRIPTION
Fixes #103

Based on #145, minus dependency updates, plus some testing and null-safety